### PR TITLE
Add bulk JSON insert API

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ canonical_str = canonical_json({"b": 1, "a": True})
 - [`create_json_table(conn, table_name="jsonstore")`](jsonstore/jsonstore/table.py): JSON全体を保存するテーブルを作成します.
 - [`insert_json(conn, canonical_json_sha1, obj, table_name="jsonstore")`](jsonstore/jsonstore/table.py): JSONを指定ハッシュで保存します.
 - [`insert_json_auto_hash(conn, obj, table_name="jsonstore")`](jsonstore/jsonstore/table.py): JSON保存時にSHA1を自動計算します.
+- [`insert_jsons_auto_hash(conn, objs, table_name="jsonstore")`](jsonstore/jsonstore/table.py): 複数のJSONを一括保存する際にSHA1を自動計算します. ハッシュ値のリストを返します.
 - [`retrieve_json(conn, canonical_json_sha1, table_name="jsonstore")`](jsonstore/jsonstore/table.py): 保存したJSONを復元します.
 
 ## テスト

--- a/jsonstore/jsonstore/__init__.py
+++ b/jsonstore/jsonstore/__init__.py
@@ -4,6 +4,7 @@ from .table import (
     create_json_table,
     insert_json,
     insert_json_auto_hash,
+    insert_jsons_auto_hash,
     retrieve_json,
     retrieve_all_json,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "create_json_table",
     "insert_json",
     "insert_json_auto_hash",
+    "insert_jsons_auto_hash",
     "retrieve_json",
     "retrieve_all_json",
     "create_json_fts",

--- a/jsonstore/jsonstore/store.py
+++ b/jsonstore/jsonstore/store.py
@@ -1,10 +1,11 @@
 import sqlite3
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from .table import (
     create_json_table,
     insert_json,
     insert_json_auto_hash,
+    insert_jsons_auto_hash,
     retrieve_json,
     retrieve_all_json,
 )
@@ -40,6 +41,14 @@ class JsonStore:
         return insert_json_auto_hash(
             self.conn,
             obj,
+            table_name=self.table_name,
+        )
+
+    def insert_jsons_auto_hash(self, objs: list[Any]) -> list[str]:
+        """Insert multiple JSON objects computing SHA1 for each."""
+        return insert_jsons_auto_hash(
+            self.conn,
+            objs,
             table_name=self.table_name,
         )
 

--- a/tests/test_jsonstore_class.py
+++ b/tests/test_jsonstore_class.py
@@ -67,3 +67,16 @@ def test_class_retrieve_all_json():
 
     assert records_sorted == data
     conn.close()
+
+
+def test_class_insert_jsons_auto_hash():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = JsonStore(conn)
+    objs = [{"a": 1}, [1, 2]]
+    hashes = store.insert_jsons_auto_hash(objs)
+    assert len(hashes) == len(objs)
+    for obj, cid in zip(objs, hashes):
+        restored = store.retrieve_json(cid)
+        assert restored == obj
+    conn.close()


### PR DESCRIPTION
## Summary
- implement `insert_jsons_auto_hash` to insert multiple JSON records at once
- expose the new helper via package `__init__` and `JsonStore`
- document the new function
- add tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b94cf05c4832ba966e4d7e649977b