### PR TITLE
Add arraystore Wikipedia titles test

### DIFF
--- a/tests/test_arraystore_wikipedia_titles.py
+++ b/tests/test_arraystore_wikipedia_titles.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import sqlite3
+import hashlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from jsonstore.arraystore.table import (
+    create_array_table,
+    insert_arrays_auto_hash,
+    retrieve_array,
+)
+from jsonstore import canonical_json
+
+SAMPLE_FILE = os.path.join(
+    os.path.dirname(__file__), "..", "samples", "jawiki-20250620-all-titles-in-ns0"
+)
+
+
+def test_bulk_insert_wikipedia_titles_as_arrays():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_array_table(conn, table_name="arraystore")
+
+    with open(SAMPLE_FILE, encoding="utf-8") as f:
+        titles = [line.rstrip("\n") for line in f]
+
+    arrays = [titles[i : i + 5] for i in range(0, len(titles), 5)]
+    hashes = insert_arrays_auto_hash(conn, arrays, table_name="arraystore")
+
+    assert len(hashes) == len(arrays)
+
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM arraystore")
+    row_count = cur.fetchone()[0]
+    assert row_count == len(titles)
+
+    for idx in [0, len(arrays) // 2, len(arrays) - 1]:
+        expected_sha1 = hashlib.sha1(
+            canonical_json(arrays[idx]).encode("utf-8")
+        ).hexdigest()
+        restored = retrieve_array(conn, expected_sha1, table_name="arraystore")
+        assert restored == arrays[idx]
+
+    conn.close()


### PR DESCRIPTION
## Summary
- add `test_bulk_insert_wikipedia_titles_as_arrays`
- verify we can chunk the Wikipedia titles file 5 at a time and bulk insert using `insert_arrays_auto_hash`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b99f96630832bb88fc6a035995c0c