### PR TITLE
Implement retrieve_all_objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ canonical_str = canonical_json({"b": 1, "a": True})
 
 - [`retrieve_object(conn, canonical_json_sha1, table_name="objectstore")`](jsonstore/objectstore/table.py):
   指定ハッシュの辞書を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
+- [`retrieve_all_objects(conn, table_name="objectstore")`](jsonstore/objectstore/table.py):
+  テーブル内のすべての辞書をリストで取得します。
 - [`create_json_table(conn, table_name="jsonstore")`](jsonstore/jsonstore/table.py): JSON全体を保存するテーブルを作成します.
 - [`insert_json(conn, canonical_json_sha1, obj, table_name="jsonstore")`](jsonstore/jsonstore/table.py): JSONを指定ハッシュで保存します.
 - [`insert_json_auto_hash(conn, obj, table_name="jsonstore")`](jsonstore/jsonstore/table.py): JSON保存時にSHA1を自動計算します.

--- a/jsonstore/objectstore/__init__.py
+++ b/jsonstore/objectstore/__init__.py
@@ -6,6 +6,7 @@ from .table import (
     insert_object_auto_hash,
     insert_objects_auto_hash,
     retrieve_object,
+    retrieve_all_objects,
 )
 from .view import create_property_concat_view
 from .fts import create_property_concat_fts
@@ -17,6 +18,7 @@ __all__ = [
     "insert_object_auto_hash",
     "insert_objects_auto_hash",
     "retrieve_object",
+    "retrieve_all_objects",
     "create_property_concat_view",
     "create_property_concat_fts",
     "ObjectStore",

--- a/jsonstore/objectstore/store.py
+++ b/jsonstore/objectstore/store.py
@@ -7,6 +7,7 @@ from .table import (
     insert_object_auto_hash,
     insert_objects_auto_hash,
     retrieve_object,
+    retrieve_all_objects,
 )
 from .view import create_property_concat_view
 from .fts import create_property_concat_fts
@@ -66,6 +67,12 @@ class ObjectStore:
         return retrieve_object(
             self.conn,
             canonical_json_sha1,
+            table_name=self.table_name,
+        )
+
+    def retrieve_all_objects(self) -> List[Dict[str, Any]]:
+        return retrieve_all_objects(
+            self.conn,
             table_name=self.table_name,
         )
 

--- a/tests/test_objectstore.py
+++ b/tests/test_objectstore.py
@@ -11,6 +11,7 @@ from jsonstore.objectstore.table import (
     insert_object_auto_hash,
     insert_objects_auto_hash,
     retrieve_object,
+    retrieve_all_objects,
 )
 from jsonstore import canonical_json
 
@@ -147,4 +148,20 @@ def test_insert_objects_auto_hash():
     for h, original in zip(hashes, objs):
         restored = retrieve_object(conn, h, table_name="objectstore")
         assert restored == original
+    conn.close()
+
+
+def test_retrieve_all_objects():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn, table_name="objectstore")
+    data = [{"v": i} for i in range(3)]
+    for obj in data:
+        insert_object_auto_hash(conn, obj, table_name="objectstore")
+
+    records = retrieve_all_objects(conn, table_name="objectstore")
+    records_sorted = sorted(records, key=lambda x: x["v"])
+
+    assert records_sorted == data
     conn.close()

--- a/tests/test_objectstore_class.py
+++ b/tests/test_objectstore_class.py
@@ -63,3 +63,19 @@ def test_class_custom_names():
     row = cur.fetchone()
     assert row[0] == "\"y\""
     conn.close()
+
+
+def test_class_retrieve_all_objects():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ObjectStore(conn)
+
+    data = [{"n": i} for i in range(4)]
+    for obj in data:
+        store.insert_object_auto_hash(obj)
+
+    records = store.retrieve_all_objects()
+    records_sorted = sorted(records, key=lambda x: x["n"])
+
+    assert records_sorted == data
+    conn.close()


### PR DESCRIPTION
## Summary
- add `retrieve_all_objects` to objectstore
- expose new API and class method
- document the new function in README
- test retrieving all objects via table function and class

## Testing
- `pip install jcs`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bc63986b0832b984a59293bb060c0