### PR TITLE
Limit test dataset lines

### DIFF
--- a/tests/test_arraystore_wikipedia_titles.py
+++ b/tests/test_arraystore_wikipedia_titles.py
@@ -2,6 +2,7 @@ import os
 import sys
 import sqlite3
 import hashlib
+import itertools
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from jsonstore.arraystore.table import (
@@ -23,7 +24,7 @@ def test_bulk_insert_wikipedia_titles_as_arrays():
     create_array_table(conn, table_name="arraystore")
 
     with open(SAMPLE_FILE, encoding="utf-8") as f:
-        titles = [line.rstrip("\n") for line in f]
+        titles = [line.rstrip("\n") for line in itertools.islice(f, 10000)]
 
     arrays = [titles[i : i + 5] for i in range(0, len(titles), 5)]
     hashes = insert_arrays_auto_hash(conn, arrays, table_name="arraystore")

--- a/tests/test_objectstore_wikipedia_titles.py
+++ b/tests/test_objectstore_wikipedia_titles.py
@@ -2,6 +2,7 @@ import os
 import sys
 import sqlite3
 import hashlib
+import itertools
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from jsonstore.objectstore.table import (
@@ -23,7 +24,7 @@ def test_bulk_insert_wikipedia_titles_as_objects():
     create_object_table(conn, table_name="objectstore")
 
     with open(SAMPLE_FILE, encoding="utf-8") as f:
-        titles = [line.rstrip("\n") for line in f]
+        titles = [line.rstrip("\n") for line in itertools.islice(f, 10000)]
 
     def make_obj(chunk):
         keys = ["one", "two", "three", "four", "five"]

--- a/tests/test_wikipedia_titles.py
+++ b/tests/test_wikipedia_titles.py
@@ -2,6 +2,7 @@ import os
 import sys
 import sqlite3
 import hashlib
+import itertools
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from jsonstore.jsonstore.table import (
@@ -24,7 +25,7 @@ def test_bulk_insert_wikipedia_titles():
     create_json_table(conn, table_name="jsonstore")
 
     with open(SAMPLE_FILE, encoding="utf-8") as f:
-        titles = [line.rstrip("\n") for line in f]
+        titles = [line.rstrip("\n") for line in itertools.islice(f, 10000)]
 
     hashes = insert_jsons_auto_hash(conn, titles, table_name="jsonstore")
 


### PR DESCRIPTION
## Summary
- limit Wikipedia title tests to the first 10k lines of the dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc9dabdb4832bb432f8510c4f254f